### PR TITLE
Implement CPU affinity on worker thread

### DIFF
--- a/files/CMakeLists.txt
+++ b/files/CMakeLists.txt
@@ -14,6 +14,9 @@ add_subdirectory(ubpf)
 FILE(GLOB_RECURSE src src/*.c)
 add_executable(delilah ${src})
 
+# Add _GNU_SOURCE flag
+target_compile_definitions(delilah PRIVATE _GNU_SOURCE)
+
 # Libraries
 target_link_libraries(delilah pthread)
 target_link_libraries(delilah ubpf)

--- a/files/include/loader/loader.h
+++ b/files/include/loader/loader.h
@@ -2,6 +2,7 @@
 #define DELILAH_LOADER_LOADER
 
 #include "delilah.h"
+#include <sched.h>
 #include <pthread.h>
 
 struct delilah_thread_t

--- a/files/src/loader/loader.c
+++ b/files/src/loader/loader.c
@@ -83,6 +83,16 @@ delilah_loader_start(struct delilah_t* delilah)
 
     pthread_create(&delilah->threads[i].thread_id, NULL, worker,
                    &delilah->threads[i]);
+
+    // Set CPU affinity
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(i, &cpuset);
+    int rc = pthread_setaffinity_np(delilah->threads[i].thread_id,
+                                    sizeof(cpu_set_t), &cpuset);
+    if (rc != 0) {
+      log_warn("Error calling pthread_setaffinity_np %d on engine %i", rc, i);
+    }
   }
 
   return 0x0;


### PR DESCRIPTION
This introduces affinity on uBPF worker threads to avoid unnecessary cache invalidations.